### PR TITLE
Add path to vscode settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,19 @@
 		"onLanguage:blade"
 	],
 	"main": "./out/extension.js",
-	"contributes": {},
+	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Livewire goto v3 configuration",
+			"properties": {
+				"livewire-goto-updated-3.path": {
+					"type": "string",
+					"default": "/app/Livewire",
+					"description": "Root path to the Livewire components folder"
+				}
+			}
+		}
+	},
 	"scripts": {
 		"vscode:prepublish": "yarn run compile",
 		"compile": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 			"type": "object",
 			"title": "Livewire goto v3 configuration",
 			"properties": {
-				"livewire-goto-updated-3.path": {
+				"livewire-goto-updated-3.pathComponents": {
 					"type": "string",
 					"default": "/app/Livewire",
 					"description": "Root path to the Livewire components folder"

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as fs from 'fs';
+import { workspace } from 'vscode';
 
 // TODO: move it to config
 // export const regexJumpFile = new RegExp('@livewire\\([\'\"](.*?)[\'\"]\\)', 'g');
@@ -42,5 +43,8 @@ export function convertNamespaceToFilePath(namespace: string): string {
 export function convertToFilePath(wsPath:string, s: string): string {
     s = (s.replace(/-./g, x=>x[1].toUpperCase())).replace(/\../g, x=>'/' + x[1].toUpperCase());
     s = s[0].toUpperCase() + s.substring(1) + ".php";
-    return wsPath + '/app/Livewire/' + s;     
+    
+    const path = workspace.getConfiguration('livewire-goto-updated-3').pathComponents;
+
+    return wsPath + path + '/' + s;   
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,7 +44,7 @@ export function convertToFilePath(wsPath:string, s: string): string {
     s = (s.replace(/-./g, x=>x[1].toUpperCase())).replace(/\../g, x=>'/' + x[1].toUpperCase());
     s = s[0].toUpperCase() + s.substring(1) + ".php";
     
-    const path = workspace.getConfiguration('livewire-goto-updated-3').pathComponents;
+    const pathComponents = workspace.getConfiguration('livewire-goto-updated-3').pathComponents;
 
-    return wsPath + path + '/' + s;   
+    return wsPath + pathComponents + '/' + s;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,7 +17,7 @@ export function getLivewireCacheMap(workspacePath: string | undefined): CacheMap
 
     const cacheFile = workspacePath + '/bootstrap/cache/livewire-components.php';
 
-    if (!fs.existsSync(cacheFile)) return map;
+    if (!fs.existsSync(cacheFile)) {return map;}
 
     const content = fs.readFileSync(cacheFile, 'utf-8');
     const matches = content.matchAll(regexCacheMap);
@@ -44,7 +44,11 @@ export function convertToFilePath(wsPath:string, s: string): string {
     s = (s.replace(/-./g, x=>x[1].toUpperCase())).replace(/\../g, x=>'/' + x[1].toUpperCase());
     s = s[0].toUpperCase() + s.substring(1) + ".php";
     
-    const pathComponents = workspace.getConfiguration('livewire-goto-updated-3').pathComponents;
+    let pathComponents = workspace.getConfiguration('livewire-goto-updated-3').pathComponents;
 
-    return wsPath + pathComponents + '/' + s;
+    if (!pathComponents.endsWith('/')) {
+        pathComponents += '/';
+    }
+
+    return wsPath + pathComponents + s;
 }


### PR DESCRIPTION
Currently the path "/app/Livewire" is hardcoded. I (and perhaps others) prefer "/app/Livewire/Components" path. 

This PR adds the option to define your own path in vscode workspace settings.